### PR TITLE
feat(docs): add Umami analytics integration

### DIFF
--- a/overrides/partials/integrations/analytics/custom.html
+++ b/overrides/partials/integrations/analytics/custom.html
@@ -1,0 +1,1 @@
+<script defer src="https://analytics.mezzogori.com/script.js" data-website-id="d9cd8538-98d4-4c60-b841-28b7099c51e7"></script>

--- a/zensical.toml
+++ b/zensical.toml
@@ -24,12 +24,16 @@ nav = [
   ]},
 ]
 
+[project.extra.analytics]
+provider = "custom"
+
 [project.markdown_extensions."pymdownx.highlight"]
 use_pygments = true
 
 [project.markdown_extensions."pymdownx.superfences"]
 
 [project.theme]
+custom_dir = "overrides"
 features = [
   "content.action.edit",
   "content.action.view",


### PR DESCRIPTION
Add self-hosted Umami analytics to track documentation visits.
Uses custom analytics provider with override partial.