### PR TITLE
feat: Gymnasium environment wrapper for RL integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ simulatte/
 │   ├── logger.py           # Logging with JSON/text/SQLite output
 │   ├── typing.py           # Shared type definitions
 │   ├── policies/           # Release policies (LumsCor, SLAR, StarvationAvoidance, triggers)
-│   └── experimental/       # Unstable modules (AGV, warehouse, materials, experimental builders/job/typing)
+│   └── experimental/       # Unstable modules (AGV, warehouse, materials, gymnasium wrapper, experimental builders/job/typing)
 ├── tests/
 │   ├── core/               # Tests for stable modules
 │   └── experimental/       # Tests for experimental modules
@@ -84,6 +84,7 @@ Simulatte is a discrete-event simulation framework for job-shop scheduling and i
 
 Unstable APIs, subject to change:
 
+- **SimulatteEnv** (`experimental/gymnasium.py`): Gymnasium ABC for wrapping simulations as RL environments. Users subclass it and implement six abstract methods (setup, get_observation, apply_action, compute_reward, is_terminated, is_truncated). Base class handles reset/step/close lifecycle, state guards, and teardown.
 - **MaterialCoordinator** (`experimental/materials.py`): FIFO material delivery coordination
 - **AGV** (`experimental/agv.py`): Automated guided vehicle transport
 - **Warehouse** (`experimental/warehouse.py`): Inventory management

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ Simulatte is a discrete-event simulation framework for job-shop scheduling and i
 
 Unstable APIs, subject to change:
 
-- **SimulatteEnv** (`experimental/gymnasium.py`): Gymnasium ABC for wrapping simulations as RL environments. Users subclass it and implement six abstract methods (setup, get_observation, apply_action, compute_reward, is_terminated, is_truncated). Base class handles reset/step/close lifecycle, state guards, and teardown.
+- **SimulatteEnv** (`experimental/gymnasium.py`): Gymnasium ABC for wrapping simulations as RL environments. Users subclass it and implement six abstract methods (setup, get_observation, apply_action, compute_reward, is_terminated, is_truncated). Two optional hooks: `teardown()` for resource cleanup between episodes, `get_info()` for step metadata. Base class handles reset/step/close lifecycle and state guards.
 - **MaterialCoordinator** (`experimental/materials.py`): FIFO material delivery coordination
 - **AGV** (`experimental/agv.py`): Automated guided vehicle transport
 - **Warehouse** (`experimental/warehouse.py`): Inventory management

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ The library provides ready-to-use components for common manufacturing scenarios 
 - Matplotlib integration: `plot_wip()`, `plot_throughput()`, `plot_lateness()`
 - Custom time-series collectors via simple protocol
 
+### Reinforcement Learning Integration *(experimental)*
+- **Gymnasium wrapper** (`SimulatteEnv`): subclass a single ABC to turn any simulation into a Gymnasium environment
+- Works with Stable-Baselines3, CleanRL, and any Gymnasium-compatible RL library
+- Built-in lifecycle guards, seeding support, and resource cleanup
+
 ### Material Handling *(experimental)*
 - Warehouse with inventory management
 - AGV fleet coordination

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ The library provides ready-to-use components for common manufacturing scenarios 
 - Custom time-series collectors via simple protocol
 
 ### Reinforcement Learning Integration *(experimental)*
-- **Gymnasium wrapper** (`SimulatteEnv`): subclass a single ABC to turn any simulation into a Gymnasium environment
-- Works with Stable-Baselines3, CleanRL, and any Gymnasium-compatible RL library
+- **Gymnasium wrapper** ([`SimulatteEnv`](https://simulatte.dev/experimental/gymnasium-wrapper/)): subclass a single ABC to turn any simulation into a Gymnasium environment (`from simulatte.experimental.gymnasium import SimulatteEnv`)
+- Can be used with Stable-Baselines3, CleanRL, and other Gymnasium-compatible RL libraries
 - Built-in lifecycle guards, seeding support, and resource cleanup
 
 ### Material Handling *(experimental)*

--- a/docs/ai-skill.md
+++ b/docs/ai-skill.md
@@ -37,11 +37,12 @@ Once installed, the skill triggers automatically when the agent detects Simulatt
 - **Operation hooks** — injecting setup times, breakdowns, or other logic before/after processing
 - **Multi-run experiments** — configuring `Runner` with seeds, parallel execution, and result extraction
 - **Result inspection** — accessing job-level, server-level, and shopfloor-level metrics
+- **Gymnasium wrapper** — wrapping simulations as Gymnasium environments for RL training with `SimulatteEnv`
 - **Common pitfalls** — generator hooks, absolute due dates, arrival rate semantics, lambda closures, and more
 
 ### What the skill does NOT cover
 
-The skill excludes experimental modules (Warehouse, AGV, MaterialCoordinator) since they are unstable and subject to breaking changes.
+The skill excludes most experimental modules (Warehouse, AGV, MaterialCoordinator) since they are unstable and subject to breaking changes. The Gymnasium wrapper (`SimulatteEnv`) is an exception — it is covered because RL integration is a common use case.
 
 ## Skill structure
 

--- a/docs/experimental/gymnasium-wrapper.md
+++ b/docs/experimental/gymnasium-wrapper.md
@@ -18,6 +18,7 @@ from simulatte.environment import Environment
 from simulatte.shopfloor import ShopFloor
 from simulatte.server import Server
 from simulatte.psp import PreShopPool
+from simulatte.job import ProductionJob
 
 
 class JobReleaseEnv(SimulatteEnv):
@@ -36,7 +37,18 @@ class JobReleaseEnv(SimulatteEnv):
             for _ in range(5)
         ]
         self.psp = PreShopPool(env=self.sim_env, shopfloor=self.shopfloor)
-        # Use self.np_random for reproducible randomness
+        # Create jobs using self.np_random for reproducibility
+        for _ in range(100):
+            routing = list(self.np_random.choice(self.servers, size=3, replace=False))
+            times = self.np_random.uniform(1.0, 5.0, size=3).tolist()
+            job = ProductionJob(
+                env=self.sim_env,
+                sku="A",
+                servers=routing,
+                processing_times=times,
+                due_date=self.sim_env.now + self.np_random.uniform(50.0, 200.0),
+            )
+            self.psp.add(job)
 
     def teardown(self):
         self.sim_env.close()
@@ -62,9 +74,9 @@ class JobReleaseEnv(SimulatteEnv):
         return self.sim_env.now > 10_000
 ```
 
-## Train with any RL library
+## Use with an RL library
 
-The resulting environment works with Stable-Baselines3, CleanRL, or any Gymnasium-compatible library:
+The resulting environment can be used with Stable-Baselines3, CleanRL, or any Gymnasium-compatible library:
 
 ```python
 env = JobReleaseEnv()
@@ -89,8 +101,10 @@ env.close()
 | `compute_reward(action)` | Yes | Compute step reward (receives the action) |
 | `is_terminated()` | Yes | Whether the episode ended naturally |
 | `is_truncated()` | Yes | Whether the episode was cut short |
-| `teardown()` | No | Clean up resources between episodes (default: no-op) |
-| `get_info()` | No | Return step info dict, called last in `step()` (default: `{}`) |
+| `teardown()` | No | Clean up resources between episodes and on `close()` (default: no-op) |
+| `get_info()` | No | Return step info dict, called last in `step()` only (default: `{}`) |
+
+> **Note:** `reset()` always returns an empty info dict `{}`. It does not call `get_info()` — that hook fires only during `step()`.
 
 ## Seeding
 
@@ -99,6 +113,8 @@ env.close()
 ```python
 def setup(self, *, seed, options):
     processing_time = self.np_random.uniform(1.0, 5.0)
+    # For non-numpy randomness, use the raw seed:
+    if seed is not None:
+        import random
+        random.seed(seed)
 ```
-
-The raw `seed` is also forwarded if you need to seed non-numpy sources (e.g., `random.seed(seed)`).

--- a/docs/experimental/gymnasium-wrapper.md
+++ b/docs/experimental/gymnasium-wrapper.md
@@ -1,0 +1,104 @@
+# Gymnasium wrapper for RL
+
+> **Experimental**: This feature is part of `simulatte.experimental` and may change in future releases.
+
+Goal: wrap a simulatte simulation as a [Gymnasium](https://gymnasium.farama.org/) environment so you can train reinforcement learning agents on it.
+
+`SimulatteEnv` is a thin abstract base class that handles the Gymnasium lifecycle (`reset`, `step`, `close`) while you define the simulation setup, observation extraction, action application, reward, and termination logic.
+
+## Define your environment
+
+Subclass `SimulatteEnv` and implement six abstract methods:
+
+```python
+import numpy as np
+from gymnasium import spaces
+from simulatte.experimental.gymnasium import SimulatteEnv
+from simulatte.environment import Environment
+from simulatte.shopfloor import ShopFloor
+from simulatte.server import Server
+from simulatte.psp import PreShopPool
+
+
+class JobReleaseEnv(SimulatteEnv):
+    def __init__(self):
+        super().__init__()
+        self.observation_space = spaces.Box(
+            low=0.0, high=np.inf, shape=(10,), dtype=np.float64,
+        )
+        self.action_space = spaces.Discrete(2)  # 0 = hold, 1 = release
+
+    def setup(self, *, seed, options):
+        self.sim_env = Environment()
+        self.shopfloor = ShopFloor(env=self.sim_env)
+        self.servers = [
+            Server(env=self.sim_env, capacity=1, shopfloor=self.shopfloor)
+            for _ in range(5)
+        ]
+        self.psp = PreShopPool(env=self.sim_env, shopfloor=self.shopfloor)
+        # Use self.np_random for reproducible randomness
+
+    def teardown(self):
+        self.sim_env.close()
+
+    def apply_action(self, action):
+        if action == 1 and len(self.psp) > 0:
+            self.psp.release(self.psp[0])
+        self.sim_env.run(until=self.sim_env.now + 10)
+
+    def get_observation(self):
+        obs = []
+        for s in self.servers:
+            obs.extend([len(s.queue), s.utilization_rate])
+        return np.array(obs, dtype=np.float64)
+
+    def compute_reward(self, action):
+        return -sum(1.0 for j in self.shopfloor.jobs_done if j.late)
+
+    def is_terminated(self):
+        return len(self.shopfloor.jobs_done) >= 100
+
+    def is_truncated(self):
+        return self.sim_env.now > 10_000
+```
+
+## Train with any RL library
+
+The resulting environment works with Stable-Baselines3, CleanRL, or any Gymnasium-compatible library:
+
+```python
+env = JobReleaseEnv()
+obs, info = env.reset(seed=42)
+
+for _ in range(1000):
+    action = env.action_space.sample()
+    obs, reward, terminated, truncated, info = env.step(action)
+    if terminated or truncated:
+        obs, info = env.reset()
+
+env.close()
+```
+
+## Method reference
+
+| Method | Abstract? | Description |
+|--------|-----------|-------------|
+| `setup(*, seed, options)` | Yes | Create and configure the simulation for a new episode |
+| `get_observation()` | Yes | Extract observation from simulation state |
+| `apply_action(action)` | Yes | Apply action and advance simulation to next decision point |
+| `compute_reward(action)` | Yes | Compute step reward (receives the action) |
+| `is_terminated()` | Yes | Whether the episode ended naturally |
+| `is_truncated()` | Yes | Whether the episode was cut short |
+| `teardown()` | No | Clean up resources between episodes (default: no-op) |
+| `get_info()` | No | Return step info dict, called last in `step()` (default: `{}`) |
+
+## Seeding
+
+`self.np_random` is a numpy `Generator` automatically seeded by Gymnasium when you call `reset(seed=...)`. Use it for all numpy-based randomness to get deterministic episodes:
+
+```python
+def setup(self, *, seed, options):
+    processing_time = self.np_random.uniform(1.0, 5.0)
+```
+
+The raw `seed` is also forwarded if you need to seed non-numpy sources (e.g., `random.seed(seed)`).

--- a/docs/experimental/index.md
+++ b/docs/experimental/index.md
@@ -4,4 +4,5 @@ This section documents features exposed under `simulatte.experimental`.
 
 These APIs are not considered stable yet: names and behavior may change between releases.
 
+- [Gymnasium wrapper for RL](gymnasium-wrapper.md): wrap a simulation as a Gymnasium environment for training RL agents.
 - [Materials, warehouse, and AGVs](materials-warehouse-agvs.md): add inventory + transport with FIFO blocking semantics.

--- a/docs/superpowers/plans/2026-04-29-gymnasium-wrapper.md
+++ b/docs/superpowers/plans/2026-04-29-gymnasium-wrapper.md
@@ -1,0 +1,772 @@
+# Gymnasium Environment Wrapper Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement a thin Gymnasium ABC (`SimulatteEnv`) in `simulatte.experimental.gymnasium` that lets developers wrap simulations as Gymnasium environments for RL training.
+
+**Architecture:** Single module with one ABC. Six abstract methods for user-defined simulation lifecycle, two optional hooks for cleanup and info. The base class handles Gymnasium `reset()`/`step()`/`close()` orchestration with lifecycle guards and state tracking. Framework-agnostic — no simulatte-specific imports.
+
+**Tech Stack:** Python 3.12+, gymnasium >= 1.0.0, pytest, ruff
+
+**Spec:** `docs/superpowers/specs/2026-04-29-gymnasium-wrapper-design.md`
+
+---
+
+## File Structure
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `src/simulatte/experimental/gymnasium.py` | `SimulatteEnv` ABC with lifecycle orchestration |
+| Modify | `src/simulatte/experimental/__init__.py` | Re-export `SimulatteEnv` |
+| Modify | `pyproject.toml` | Add `gymnasium>=1.0.0` dependency |
+| Create | `tests/experimental/test_gymnasium.py` | Contract, compliance, determinism, integration tests |
+
+---
+
+### Task 1: Add gymnasium dependency
+
+**Files:**
+- Modify: `pyproject.toml:25-31`
+
+- [ ] **Step 1: Add gymnasium to project dependencies**
+
+In `pyproject.toml`, add `"gymnasium>=1.0.0"` to the `dependencies` list:
+
+```toml
+dependencies = [
+    "simpy>=4.0.1",
+    "matplotlib>=3.7.2",
+    "tabulate>=0.9.0",
+    "loguru>=0.7.2",
+    "tqdm>=4.67.1",
+    "gymnasium>=1.0.0",
+]
+```
+
+- [ ] **Step 2: Sync the environment**
+
+Run: `uv sync --dev`
+Expected: gymnasium is installed, no errors.
+
+- [ ] **Step 3: Verify import**
+
+Run: `uv run python -c "import gymnasium; print(gymnasium.__version__)"`
+Expected: Prints version >= 1.0.0
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "feat: add gymnasium dependency"
+```
+
+---
+
+### Task 2: Write contract tests for lifecycle guards
+
+**Files:**
+- Create: `tests/experimental/test_gymnasium.py`
+
+These tests define the contract BEFORE the implementation exists. They will fail until Task 4.
+
+- [ ] **Step 1: Write the test file with a minimal concrete subclass and all contract tests**
+
+Create `tests/experimental/test_gymnasium.py`:
+
+```python
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from gymnasium import spaces
+
+from simulatte.experimental.gymnasium import SimulatteEnv
+
+
+class MinimalEnv(SimulatteEnv):
+    """Minimal concrete subclass for testing the base class contract."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.observation_space = spaces.Box(low=0.0, high=1.0, shape=(2,), dtype=np.float64)
+        self.action_space = spaces.Discrete(2)
+        self.step_count = 0
+        self.max_steps = 3
+        self.setup_calls: list[int | None] = []
+        self.teardown_calls: int = 0
+
+    def setup(self, *, seed: int | None, options: dict | None) -> None:
+        self.step_count = 0
+        self.setup_calls.append(seed)
+
+    def teardown(self) -> None:
+        self.teardown_calls += 1
+
+    def get_observation(self):
+        return np.array([0.5, 0.5], dtype=np.float64)
+
+    def apply_action(self, action) -> None:
+        self.step_count += 1
+
+    def compute_reward(self, action) -> float:
+        return 1.0
+
+    def is_terminated(self) -> bool:
+        return self.step_count >= self.max_steps
+
+    def is_truncated(self) -> bool:
+        return False
+
+
+class TestLifecycleGuards:
+    """Verify that step() raises RuntimeError in invalid states."""
+
+    def test_step_before_reset_raises(self) -> None:
+        env = MinimalEnv()
+        with pytest.raises(RuntimeError, match="Call reset\\(\\) first"):
+            env.step(0)
+
+    def test_step_after_terminated_raises(self) -> None:
+        env = MinimalEnv()
+        env.max_steps = 1
+        env.reset(seed=42)
+        _, _, terminated, _, _ = env.step(0)
+        assert terminated
+        with pytest.raises(RuntimeError, match="Call reset\\(\\) first"):
+            env.step(0)
+
+    def test_step_after_truncated_raises(self) -> None:
+        env = MinimalEnv()
+        env.reset(seed=42)
+        # Override is_truncated to return True on first step
+        env.is_truncated = lambda: True  # type: ignore[assignment]
+        _, _, _, truncated, _ = env.step(0)
+        assert truncated
+        with pytest.raises(RuntimeError, match="Call reset\\(\\) first"):
+            env.step(0)
+
+
+class TestResetLifecycle:
+    """Verify reset/teardown call ordering."""
+
+    def test_first_reset_does_not_call_teardown(self) -> None:
+        env = MinimalEnv()
+        env.reset(seed=42)
+        assert env.teardown_calls == 0
+        assert env.setup_calls == [42]
+
+    def test_second_reset_calls_teardown_before_setup(self) -> None:
+        env = MinimalEnv()
+        env.reset(seed=1)
+        env.reset(seed=2)
+        assert env.teardown_calls == 1
+        assert env.setup_calls == [1, 2]
+
+    def test_reset_after_done_resets_lifecycle(self) -> None:
+        env = MinimalEnv()
+        env.max_steps = 1
+        env.reset(seed=10)
+        env.step(0)  # terminates
+        env.reset(seed=20)  # should work, not raise
+        obs, _ = env.reset(seed=30)
+        assert obs is not None
+
+
+class TestCloseLifecycle:
+    """Verify close() teardown behavior."""
+
+    def test_close_without_reset_does_not_call_teardown(self) -> None:
+        env = MinimalEnv()
+        env.close()
+        assert env.teardown_calls == 0
+
+    def test_close_after_reset_calls_teardown(self) -> None:
+        env = MinimalEnv()
+        env.reset(seed=42)
+        env.close()
+        assert env.teardown_calls == 1
+
+    def test_close_then_step_raises(self) -> None:
+        env = MinimalEnv()
+        env.reset(seed=42)
+        env.close()
+        with pytest.raises(RuntimeError, match="Call reset\\(\\) first"):
+            env.step(0)
+
+
+class TestStepCallOrder:
+    """Verify step() returns correct 5-tuple in correct order."""
+
+    def test_step_returns_five_tuple(self) -> None:
+        env = MinimalEnv()
+        env.reset(seed=42)
+        result = env.step(0)
+        assert len(result) == 5
+        obs, reward, terminated, truncated, info = result
+        assert isinstance(obs, np.ndarray)
+        assert isinstance(reward, float)
+        assert isinstance(terminated, bool)
+        assert isinstance(truncated, bool)
+        assert isinstance(info, dict)
+
+    def test_reset_returns_obs_and_info(self) -> None:
+        env = MinimalEnv()
+        result = env.reset(seed=42)
+        assert len(result) == 2
+        obs, info = result
+        assert isinstance(obs, np.ndarray)
+        assert isinstance(info, dict)
+
+
+class TestGetInfo:
+    """Verify get_info() is called and its return is used."""
+
+    def test_default_get_info_returns_empty_dict(self) -> None:
+        env = MinimalEnv()
+        env.reset(seed=42)
+        _, _, _, _, info = env.step(0)
+        assert info == {}
+
+    def test_custom_get_info_is_used(self) -> None:
+        class InfoEnv(MinimalEnv):
+            def get_info(self):
+                return {"step": self.step_count}
+
+        env = InfoEnv()
+        env.reset(seed=42)
+        _, _, _, _, info = env.step(0)
+        assert info == {"step": 1}
+
+
+class TestComputeRewardReceivesAction:
+    """Verify compute_reward() receives the action passed to step()."""
+
+    def test_reward_receives_action(self) -> None:
+        class ActionRewardEnv(MinimalEnv):
+            def compute_reward(self, action) -> float:
+                return -10.0 if action == 1 else 0.0
+
+        env = ActionRewardEnv()
+        env.reset(seed=42)
+        _, reward_0, _, _, _ = env.step(0)
+        assert reward_0 == 0.0
+
+        env.reset(seed=42)
+        _, reward_1, _, _, _ = env.step(1)
+        assert reward_1 == -10.0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/experimental/test_gymnasium.py -v`
+Expected: ImportError — `simulatte.experimental.gymnasium` does not exist yet.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/experimental/test_gymnasium.py
+git commit -m "test: add contract tests for SimulatteEnv lifecycle"
+```
+
+---
+
+### Task 3: Write seeded determinism tests
+
+**Files:**
+- Modify: `tests/experimental/test_gymnasium.py`
+
+- [ ] **Step 1: Add a stochastic subclass and determinism tests**
+
+Append to `tests/experimental/test_gymnasium.py`:
+
+```python
+class StochasticEnv(SimulatteEnv):
+    """Subclass that uses self.np_random to produce stochastic observations."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.observation_space = spaces.Box(low=0.0, high=100.0, shape=(1,), dtype=np.float64)
+        self.action_space = spaces.Discrete(2)
+        self.step_count = 0
+
+    def setup(self, *, seed: int | None, options: dict | None) -> None:
+        self.step_count = 0
+
+    def get_observation(self):
+        return np.array([self.np_random.uniform(0.0, 100.0)], dtype=np.float64)
+
+    def apply_action(self, action) -> None:
+        self.step_count += 1
+
+    def compute_reward(self, action) -> float:
+        return self.np_random.uniform(-1.0, 1.0)
+
+    def is_terminated(self) -> bool:
+        return self.step_count >= 5
+
+    def is_truncated(self) -> bool:
+        return False
+
+
+class TestSeededDeterminism:
+    """Verify that seeding produces reproducible trajectories."""
+
+    @staticmethod
+    def _collect_trajectory(env: StochasticEnv, seed: int, actions: list[int]) -> tuple[list, list]:
+        observations = []
+        rewards = []
+        obs, _ = env.reset(seed=seed)
+        observations.append(obs.copy())
+        for action in actions:
+            obs, reward, terminated, truncated, _ = env.step(action)
+            observations.append(obs.copy())
+            rewards.append(reward)
+            if terminated or truncated:
+                break
+        return observations, rewards
+
+    def test_same_seed_same_trajectory(self) -> None:
+        env = StochasticEnv()
+        actions = [0, 1, 0, 1, 0]
+        obs_1, rew_1 = self._collect_trajectory(env, seed=42, actions=actions)
+        obs_2, rew_2 = self._collect_trajectory(env, seed=42, actions=actions)
+        for o1, o2 in zip(obs_1, obs_2, strict=True):
+            np.testing.assert_array_equal(o1, o2)
+        assert rew_1 == rew_2
+
+    def test_different_seed_different_trajectory(self) -> None:
+        env = StochasticEnv()
+        actions = [0, 1, 0, 1, 0]
+        obs_1, _ = self._collect_trajectory(env, seed=42, actions=actions)
+        obs_2, _ = self._collect_trajectory(env, seed=99, actions=actions)
+        any_different = any(not np.array_equal(o1, o2) for o1, o2 in zip(obs_1, obs_2, strict=True))
+        assert any_different
+```
+
+- [ ] **Step 2: Run tests to verify they still fail (ImportError)**
+
+Run: `uv run pytest tests/experimental/test_gymnasium.py -v`
+Expected: ImportError — module not yet implemented.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/experimental/test_gymnasium.py
+git commit -m "test: add seeded determinism tests for SimulatteEnv"
+```
+
+---
+
+### Task 4: Implement SimulatteEnv
+
+**Files:**
+- Create: `src/simulatte/experimental/gymnasium.py`
+
+- [ ] **Step 1: Write the full implementation**
+
+Create `src/simulatte/experimental/gymnasium.py`:
+
+```python
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+import gymnasium
+
+
+class SimulatteEnv(gymnasium.Env, ABC):
+    """Base class for wrapping simulations as Gymnasium environments.
+
+    Subclass this and implement the six abstract methods to define your
+    simulation's observation space, action space, setup, reward, and
+    termination logic. The base class handles Gymnasium lifecycle
+    orchestration, state tracking, and resource cleanup.
+
+    Two optional hooks are available:
+    - ``teardown()``: clean up simulation resources between episodes.
+    - ``get_info()``: return step metadata after all computations.
+
+    Subclasses must set ``observation_space`` and ``action_space`` in
+    ``__init__`` before calling ``reset()``.
+    """
+
+    _is_initialized: bool = False
+    _done: bool = False
+
+    @abstractmethod
+    def setup(self, *, seed: int | None, options: dict[str, Any] | None) -> None:
+        """Create and configure the simulation from scratch.
+
+        Called at the beginning of each episode. Must set up all simulation
+        state needed for the episode.
+
+        For numpy-based randomness, prefer ``self.np_random`` — it is
+        automatically seeded by Gymnasium and persists correctly across
+        unseeded resets.
+        """
+
+    @abstractmethod
+    def get_observation(self) -> Any:
+        """Extract the current observation from the simulation state."""
+
+    @abstractmethod
+    def apply_action(self, action: Any) -> None:
+        """Apply the agent's action and advance the simulation to the next decision point."""
+
+    @abstractmethod
+    def compute_reward(self, action: Any) -> float:
+        """Compute the reward for the current step."""
+
+    @abstractmethod
+    def is_terminated(self) -> bool:
+        """Whether the episode ended naturally."""
+
+    @abstractmethod
+    def is_truncated(self) -> bool:
+        """Whether the episode was cut short."""
+
+    def teardown(self) -> None:
+        """Clean up simulation resources from the previous episode.
+
+        Called before ``setup()`` on every ``reset()`` after the first,
+        and from ``close()``.
+        """
+
+    def get_info(self) -> dict[str, Any]:
+        """Return the info dict for this step.
+
+        Called last in ``step()``, after observation, reward, and
+        termination have all been computed.
+        """
+        return {}
+
+    def reset(
+        self,
+        *,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[Any, dict[str, Any]]:
+        super().reset(seed=seed, options=options)
+        if self._is_initialized:
+            self.teardown()
+        self.setup(seed=seed, options=options)
+        self._is_initialized = True
+        self._done = False
+        return self.get_observation(), {}
+
+    def step(self, action: Any) -> tuple[Any, float, bool, bool, dict[str, Any]]:
+        if not self._is_initialized or self._done:
+            msg = "Cannot call step() before reset() or after episode end. Call reset() first."
+            raise RuntimeError(msg)
+        self.apply_action(action)
+        obs = self.get_observation()
+        reward = self.compute_reward(action)
+        terminated = self.is_terminated()
+        truncated = self.is_truncated()
+        if terminated or truncated:
+            self._done = True
+        info = self.get_info()
+        return obs, reward, terminated, truncated, info
+
+    def close(self) -> None:
+        if self._is_initialized:
+            self.teardown()
+            self._is_initialized = False
+        super().close()
+```
+
+- [ ] **Step 2: Run the contract and determinism tests**
+
+Run: `uv run pytest tests/experimental/test_gymnasium.py -v`
+Expected: All tests pass.
+
+- [ ] **Step 3: Run ruff to check style compliance**
+
+Run: `uv run ruff check src/simulatte/experimental/gymnasium.py`
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/simulatte/experimental/gymnasium.py
+git commit -m "feat: implement SimulatteEnv gymnasium wrapper"
+```
+
+---
+
+### Task 5: Export from experimental __init__.py
+
+**Files:**
+- Modify: `src/simulatte/experimental/__init__.py`
+
+- [ ] **Step 1: Add the import and __all__ entry**
+
+Add the import of `SimulatteEnv` and add it to `__all__` in `src/simulatte/experimental/__init__.py`:
+
+```python
+"""Experimental features for material handling, warehouse, and AGV operations.
+
+This module contains less mature implementations that are complete and tested
+but not yet considered stable for the core API. These features may change
+in future releases.
+
+Exports:
+    AGV: Automated guided vehicle server for transport operations.
+    MaterialCoordinator: Orchestrates material delivery with FIFO blocking.
+    MaterialSystem: Type alias for material handling system tuple.
+    MaterialSystemBuilder: Factory for building material handling systems.
+    SimulatteEnv: Gymnasium environment base class for RL integration.
+    TransportJob: Job type for AGV transport operations.
+    Warehouse: Warehouse server with inventory containers.
+    WarehouseJob: Job type for warehouse pick/put operations.
+"""
+
+from __future__ import annotations
+
+from simulatte.experimental.agv import AGV
+from simulatte.experimental.builders import MaterialSystemBuilder
+from simulatte.experimental.gymnasium import SimulatteEnv
+from simulatte.experimental.job import TransportJob, WarehouseJob
+from simulatte.experimental.materials import MaterialCoordinator
+from simulatte.experimental.typing import MaterialSystem
+from simulatte.experimental.warehouse import Warehouse
+
+__all__ = [
+    "AGV",
+    "MaterialCoordinator",
+    "MaterialSystem",
+    "MaterialSystemBuilder",
+    "SimulatteEnv",
+    "TransportJob",
+    "Warehouse",
+    "WarehouseJob",
+]
+```
+
+- [ ] **Step 2: Verify the re-export works**
+
+Run: `uv run python -c "from simulatte.experimental import SimulatteEnv; print(SimulatteEnv)"`
+Expected: Prints `<class 'simulatte.experimental.gymnasium.SimulatteEnv'>`
+
+- [ ] **Step 3: Run full test suite to check for regressions**
+
+Run: `uv run pytest -v`
+Expected: All tests pass, including the new gymnasium tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/simulatte/experimental/__init__.py
+git commit -m "feat: export SimulatteEnv from experimental package"
+```
+
+---
+
+### Task 6: Add Gymnasium baseline compliance test
+
+**Files:**
+- Modify: `tests/experimental/test_gymnasium.py`
+
+- [ ] **Step 1: Add the check_env test**
+
+Append to `tests/experimental/test_gymnasium.py`:
+
+```python
+from gymnasium.utils.env_checker import check_env
+
+
+class TestGymnasiumCompliance:
+    """Run Gymnasium's built-in env checker for baseline API compliance."""
+
+    def test_check_env_passes(self) -> None:
+        env = MinimalEnv()
+        check_env(env.unwrapped, skip_render_check=True)
+```
+
+- [ ] **Step 2: Run the new test**
+
+Run: `uv run pytest tests/experimental/test_gymnasium.py::TestGymnasiumCompliance -v`
+Expected: PASS. If `check_env` raises a warning or error, fix the issue in `src/simulatte/experimental/gymnasium.py` and re-run.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/experimental/test_gymnasium.py
+git commit -m "test: add Gymnasium baseline compliance check"
+```
+
+---
+
+### Task 7: Add integration test with real simulatte simulation
+
+**Files:**
+- Modify: `tests/experimental/test_gymnasium.py`
+
+- [ ] **Step 1: Add the integration test**
+
+Append to `tests/experimental/test_gymnasium.py`:
+
+```python
+from simulatte.environment import Environment
+from simulatte.job import ProductionJob
+from simulatte.server import Server
+from simulatte.shopfloor import ShopFloor
+
+
+class SimulatteIntegrationEnv(SimulatteEnv):
+    """A real simulatte simulation wrapped as a Gymnasium environment."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.observation_space = spaces.Box(low=0.0, high=np.inf, shape=(4,), dtype=np.float64)
+        self.action_space = spaces.Discrete(2)
+
+    def setup(self, *, seed: int | None, options: dict | None) -> None:
+        self.sim_env = Environment()
+        self.shopfloor = ShopFloor(env=self.sim_env)
+        self.servers = [
+            Server(env=self.sim_env, capacity=1, shopfloor=self.shopfloor),
+            Server(env=self.sim_env, capacity=1, shopfloor=self.shopfloor),
+        ]
+        self.jobs_released = 0
+        self.total_jobs = 5
+        self._rng = self.np_random
+        self._pending_jobs = [
+            ProductionJob(
+                env=self.sim_env,
+                sku="A",
+                servers=self.servers,
+                processing_times=[self._rng.uniform(1.0, 5.0), self._rng.uniform(1.0, 5.0)],
+                due_date=50.0,
+            )
+            for _ in range(self.total_jobs)
+        ]
+
+    def teardown(self) -> None:
+        self.sim_env.close()
+
+    def apply_action(self, action) -> None:
+        if action == 1 and self._pending_jobs:
+            job = self._pending_jobs.pop(0)
+            self.shopfloor.add(job)
+            self.jobs_released += 1
+        self.sim_env.run(until=self.sim_env.now + 5.0)
+
+    def get_observation(self):
+        return np.array(
+            [
+                len(self.servers[0].queue),
+                len(self.servers[1].queue),
+                self.sim_env.now,
+                len(self._pending_jobs),
+            ],
+            dtype=np.float64,
+        )
+
+    def compute_reward(self, action) -> float:
+        return -sum(1.0 for job in self.shopfloor.jobs_done if job.late)
+
+    def is_terminated(self) -> bool:
+        return len(self.shopfloor.jobs_done) >= self.total_jobs
+
+    def is_truncated(self) -> bool:
+        return self.sim_env.now > 200.0
+
+
+class TestSimulatteIntegration:
+    """Integration test using real simulatte simulation components."""
+
+    def test_full_episode(self) -> None:
+        env = SimulatteIntegrationEnv()
+        obs, info = env.reset(seed=42)
+        assert obs.shape == (4,)
+        assert info == {}
+
+        done = False
+        steps = 0
+        while not done:
+            action = 1 if obs[3] > 0 else 0  # release if pending jobs remain
+            obs, reward, terminated, truncated, info = env.step(action)
+            done = terminated or truncated
+            steps += 1
+
+        assert steps > 0
+        assert len(env.shopfloor.jobs_done) > 0
+        env.close()
+
+    def test_multiple_episodes_with_teardown(self) -> None:
+        env = SimulatteIntegrationEnv()
+        for seed in [1, 2, 3]:
+            obs, _ = env.reset(seed=seed)
+            for _ in range(3):
+                obs, _, terminated, truncated, _ = env.step(1)
+                if terminated or truncated:
+                    break
+        env.close()
+
+    def test_deterministic_episodes(self) -> None:
+        env = SimulatteIntegrationEnv()
+
+        def run_episode(seed: int) -> list:
+            obs_list = []
+            obs, _ = env.reset(seed=seed)
+            obs_list.append(obs.copy())
+            for _ in range(5):
+                obs, _, terminated, truncated, _ = env.step(1)
+                obs_list.append(obs.copy())
+                if terminated or truncated:
+                    break
+            return obs_list
+
+        traj_1 = run_episode(seed=42)
+        traj_2 = run_episode(seed=42)
+        for o1, o2 in zip(traj_1, traj_2, strict=True):
+            np.testing.assert_array_equal(o1, o2)
+
+        env.close()
+```
+
+- [ ] **Step 2: Run all tests**
+
+Run: `uv run pytest tests/experimental/test_gymnasium.py -v`
+Expected: All tests pass.
+
+- [ ] **Step 3: Run full test suite for regressions**
+
+Run: `uv run pytest -v`
+Expected: All tests pass, coverage >= 99%.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/experimental/test_gymnasium.py
+git commit -m "test: add simulatte integration tests for gymnasium wrapper"
+```
+
+---
+
+### Task 8: Final verification
+
+- [ ] **Step 1: Run ruff on all changed files**
+
+Run: `uv run ruff check src/simulatte/experimental/gymnasium.py src/simulatte/experimental/__init__.py tests/experimental/test_gymnasium.py`
+Expected: No errors.
+
+- [ ] **Step 2: Run full test suite with coverage**
+
+Run: `uv run pytest -v`
+Expected: All tests pass, branch coverage >= 99%.
+
+- [ ] **Step 3: Verify type checking**
+
+Run: `uv run ty check`
+Expected: No new errors introduced.
+
+- [ ] **Step 4: Final commit if any fixups needed**
+
+Only if Steps 1-3 required changes:
+```bash
+git add -u
+git commit -m "chore: fixups from final verification"
+```

--- a/docs/superpowers/specs/2026-04-29-gymnasium-wrapper-design.md
+++ b/docs/superpowers/specs/2026-04-29-gymnasium-wrapper-design.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-A thin abstract base class that lets developers wrap any simulatte simulation as a Gymnasium environment for training RL agents. The wrapper is framework-agnostic — it handles Gymnasium lifecycle plumbing without encoding simulatte-specific assumptions. Users subclass it and implement six abstract methods to define their observation space, action space, simulation setup, reward function, and termination conditions.
+A thin abstract base class that lets developers wrap any simulatte simulation as a Gymnasium environment for training RL agents. The wrapper is framework-agnostic — it handles Gymnasium lifecycle plumbing without encoding simulatte-specific assumptions. Users subclass it and implement six abstract methods to define their observation space, action space, simulation setup, reward function, and termination conditions. Two optional hooks (`teardown()` and `get_info()`) handle resource cleanup and step metadata.
 
 ## Requirements
 
@@ -14,7 +14,9 @@ A thin abstract base class that lets developers wrap any simulatte simulation as
 - User-defined step boundaries: the user controls time advancement inside `apply_action()`
 - Single ABC interface: users subclass and override abstract methods
 - User defines `observation_space`, `action_space`, `is_terminated()`, `is_truncated()`
-- Seed forwarded to user's builder with no automatic seeding magic
+- Seed forwarded to user's builder; `self.np_random` (seeded by Gymnasium) is the recommended RNG
+- Lifecycle guards: `step()` raises if called before `reset()` or after episode end
+- Resource cleanup via optional `teardown()` hook
 - No rendering support in v1
 - No simulatte-specific imports or assumptions in the base class
 
@@ -27,6 +29,8 @@ A thin abstract base class that lets developers wrap any simulatte simulation as
 **Public API:** `SimulatteEnv` class, re-exported from `src/simulatte/experimental/__init__.py`.
 
 ## ABC Interface
+
+Six abstract methods and two optional hooks:
 
 ```python
 from abc import ABC, abstractmethod
@@ -43,6 +47,17 @@ class SimulatteEnv(gymnasium.Env, ABC):
 
         Called at the beginning of each episode. Must set up all simulation
         state (environment, servers, jobs, etc.) needed for the episode.
+
+        The `seed` parameter is forwarded from `reset(seed=...)`. For
+        numpy-based randomness, prefer `self.np_random` — it is automatically
+        seeded by Gymnasium's `super().reset()` and persists correctly across
+        unseeded resets. Use `seed` directly only for sources that cannot
+        consume a numpy Generator (e.g., `random.seed(seed)`).
+
+        Pitfall: after `reset(seed=42)`, a subsequent `reset()` passes
+        `seed=None`. Code like `np.random.default_rng(seed)` would get
+        entropy instead of deterministic continuation. `self.np_random`
+        handles this correctly.
         """
 
     @abstractmethod
@@ -50,15 +65,21 @@ class SimulatteEnv(gymnasium.Env, ABC):
         """Extract the current observation from the simulation state."""
 
     @abstractmethod
-    def apply_action(self, action: Any) -> dict[str, Any]:
+    def apply_action(self, action: Any) -> None:
         """Apply the agent's action and advance the simulation to the next decision point.
 
-        Returns the info dict for this step.
+        This method has a single responsibility: mutate the simulation state
+        and advance time. It does not return a value. Use `get_info()` to
+        surface step metadata.
         """
 
     @abstractmethod
-    def compute_reward(self) -> float:
-        """Compute the reward for the current step."""
+    def compute_reward(self, action: Any) -> float:
+        """Compute the reward for the current step.
+
+        Receives the action so that action-dependent costs or penalties
+        can be computed without storing side-effect state.
+        """
 
     @abstractmethod
     def is_terminated(self) -> bool:
@@ -67,32 +88,94 @@ class SimulatteEnv(gymnasium.Env, ABC):
     @abstractmethod
     def is_truncated(self) -> bool:
         """Whether the episode was cut short (e.g., time budget exceeded)."""
+
+    # --- Optional hooks (non-abstract, safe defaults) ---
+
+    def teardown(self) -> None:
+        """Clean up simulation resources from the previous episode.
+
+        Called before `setup()` on every `reset()` after the first, and
+        from `close()`. Override to release log files, database connections,
+        or other resources held by the simulation.
+        """
+
+    def get_info(self) -> dict[str, Any]:
+        """Return the info dict for this step.
+
+        Called last in `step()`, after observation, reward, and termination
+        have all been computed. Override to include reward decomposition,
+        terminal-reason flags, diagnostic metrics, etc.
+        """
+        return {}
 ```
+
+**Design notes:**
+
+- `apply_action()` returns `None`. Info is decoupled into `get_info()`, called last in `step()`, so it can reference reward, termination, or any other computed value.
+- `compute_reward(action)` receives the action for action-dependent rewards (penalties, costs). All other state is accessible via `self`.
+- `teardown()` and `get_info()` are not abstract — they have safe defaults. Users override only when needed.
 
 ## Lifecycle Orchestration
 
-The base class implements `reset()` and `step()`:
+The base class implements `reset()`, `step()`, and `close()` with state tracking:
 
 ```python
     def reset(self, *, seed: int | None = None, options: dict[str, Any] | None = None):
         super().reset(seed=seed, options=options)
+        if self._is_initialized:
+            self.teardown()
         self.setup(seed=seed, options=options)
+        self._is_initialized = True
+        self._done = False
         return self.get_observation(), {}
 
     def step(self, action: Any):
-        info = self.apply_action(action)
+        if not self._is_initialized or self._done:
+            msg = "Cannot call step() before reset() or after episode end. Call reset() first."
+            raise RuntimeError(msg)
+        self.apply_action(action)
         obs = self.get_observation()
-        reward = self.compute_reward()
+        reward = self.compute_reward(action)
         terminated = self.is_terminated()
         truncated = self.is_truncated()
+        if terminated or truncated:
+            self._done = True
+        info = self.get_info()
         return obs, reward, terminated, truncated, info
+
+    def close(self) -> None:
+        if self._is_initialized:
+            self.teardown()
+            self._is_initialized = False
+        super().close()
 ```
 
-**Call order in `step()`:** action first (advances simulation), then observe the resulting state, then evaluate reward and termination on the new state.
+**State tracking:**
 
-**`super().reset()`** is called first in `reset()` as required by Gymnasium — this handles internal `self.np_random` seeding.
+- `_is_initialized` (`bool`, initially `False`): whether `setup()` has been called at least once. Guards `teardown()` calls and `step()` access.
+- `_done` (`bool`, initially `False`): whether the current episode has ended. Set to `True` when `is_terminated()` or `is_truncated()` returns `True`. Guards against `step()` after episode end.
 
-**`reset()` info dict** is always empty. If setup diagnostics are needed later, `setup()` can be changed to return an optional dict.
+**Call order in `step()`:** guard check, apply action (advance simulation), observe resulting state, compute reward (with action), evaluate termination, collect info. Info is last so it can reference all prior computations.
+
+**`super().reset()`** is called first in `reset()` as required by Gymnasium — this seeds `self.np_random`. On subsequent resets without a seed, `self.np_random` continues deterministically from its current state.
+
+**Teardown lifecycle:** On the first `reset()`, no teardown occurs (nothing to clean up). On subsequent resets, `teardown()` is called before `setup()`. On `close()`, `teardown()` is called once if the env was initialized.
+
+## Seeding and Reproducibility
+
+Gymnasium provides `self.np_random` — a `numpy.random.Generator` instance seeded automatically by `super().reset(seed=...)`. This is the recommended RNG for all numpy-based randomness in the simulation.
+
+**Contract:**
+
+- `reset(seed=42)` → `self.np_random` is seeded with 42. `setup()` receives `seed=42`.
+- `reset()` → `self.np_random` continues from its current state. `setup()` receives `seed=None`.
+- `reset(seed=42)` again → identical `self.np_random` state, deterministic replay.
+
+**Guidance for subclass authors:**
+
+- Use `self.np_random` for numpy-based distributions (inter-arrival times, processing times, etc.).
+- Use `seed` directly only for non-numpy randomness (e.g., `random.seed(seed)` for Python stdlib).
+- If the simulation uses external libraries with their own RNG, derive seeds from `self.np_random` to maintain determinism: `lib_seed = int(self.np_random.integers(2**31))`.
 
 ## Usage Example
 
@@ -118,7 +201,11 @@ class JobReleaseEnv(SimulatteEnv):
 
     def setup(self, *, seed, options):
         self.sim_env = Environment()
-        rng = np.random.default_rng(seed)
+        # Seed Python's random for any stdlib-based randomness
+        if seed is not None:
+            import random
+            random.seed(seed)
+        # Use self.np_random for numpy-based distributions
         self.shopfloor = ShopFloor(env=self.sim_env)
         self.servers = [
             Server(env=self.sim_env, capacity=1, shopfloor=self.shopfloor)
@@ -126,11 +213,14 @@ class JobReleaseEnv(SimulatteEnv):
         ]
         self.psp = PSP(env=self.sim_env, shopfloor=self.shopfloor)
 
+    def teardown(self):
+        # Clean up simulation resources if needed
+        pass
+
     def apply_action(self, action):
         if action == 1 and len(self.psp) > 0:
-            self.psp.release(self.psp.jobs[0])
+            self.psp.release(self.psp[0])
         self.sim_env.run(until=self.sim_env.now + 10)
-        return {}
 
     def get_observation(self):
         obs = []
@@ -138,7 +228,7 @@ class JobReleaseEnv(SimulatteEnv):
             obs.extend([len(server.queue), server.utilization_rate])
         return np.array(obs, dtype=np.float64)
 
-    def compute_reward(self):
+    def compute_reward(self, action):
         return -sum(job.lateness for job in self.shopfloor.jobs_done[-5:] if job.late)
 
     def is_terminated(self):
@@ -150,11 +240,12 @@ class JobReleaseEnv(SimulatteEnv):
 
 ## Testing Strategy
 
-Tests live in `tests/experimental/test_gymnasium.py`. Three levels:
+Tests live in `tests/experimental/test_gymnasium.py`. Four levels:
 
-1. **Contract tests** — A minimal concrete subclass with trivial implementations. Verify correct call order, return types and shapes, and that `super().reset()` is called.
-2. **Gymnasium compliance** — Run `gymnasium.utils.env_checker.check_env()` on the minimal subclass. This validates space consistency, dtype correctness, and full API compliance.
-3. **Integration test** — A small real simulatte simulation (2 servers, a handful of jobs) wrapped as a Gymnasium env, run for a few episodes. Validates the full loop with actual SimPy event processing.
+1. **Contract tests** — A minimal concrete subclass with trivial implementations. Verify correct call order, return types and shapes, that `super().reset()` is called, and that lifecycle guards raise `RuntimeError` on `step()` before `reset()` and after episode end.
+2. **Gymnasium baseline checks** — Run `gymnasium.utils.env_checker.check_env()` on the minimal subclass. This validates space consistency, dtype correctness, and basic API compliance. Note: this does not cover subclass-specific issues like SimPy boundary correctness or resource leaks.
+3. **Seeded determinism test** — Verify that same seed + same action sequence produces identical trajectories (observations, rewards, termination points). Verify that different seeds produce different trajectories.
+4. **Integration test** — A small real simulatte simulation (2 servers, a handful of jobs) wrapped as a Gymnasium env, run for a few episodes. Validates the full loop with actual SimPy event processing, including teardown between episodes.
 
 ## Scope Boundaries
 

--- a/docs/superpowers/specs/2026-04-29-gymnasium-wrapper-design.md
+++ b/docs/superpowers/specs/2026-04-29-gymnasium-wrapper-design.md
@@ -33,7 +33,6 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 import gymnasium
-import numpy as np
 
 
 class SimulatteEnv(gymnasium.Env, ABC):

--- a/docs/superpowers/specs/2026-04-29-gymnasium-wrapper-design.md
+++ b/docs/superpowers/specs/2026-04-29-gymnasium-wrapper-design.md
@@ -1,0 +1,176 @@
+# Gymnasium Environment Wrapper — Design Spec
+
+**Date:** 2026-04-29
+**Status:** Approved
+**Module:** `simulatte.experimental.gymnasium`
+
+## Overview
+
+A thin abstract base class that lets developers wrap any simulatte simulation as a Gymnasium environment for training RL agents. The wrapper is framework-agnostic — it handles Gymnasium lifecycle plumbing without encoding simulatte-specific assumptions. Users subclass it and implement six abstract methods to define their observation space, action space, simulation setup, reward function, and termination conditions.
+
+## Requirements
+
+- Fully general: agnostic to the specific RL decision problem (job release, dispatching, combined, etc.)
+- User-defined step boundaries: the user controls time advancement inside `apply_action()`
+- Single ABC interface: users subclass and override abstract methods
+- User defines `observation_space`, `action_space`, `is_terminated()`, `is_truncated()`
+- Seed forwarded to user's builder with no automatic seeding magic
+- No rendering support in v1
+- No simulatte-specific imports or assumptions in the base class
+
+## Module Structure
+
+**Location:** `src/simulatte/experimental/gymnasium.py` — single module, not a subpackage.
+
+**Dependency:** `gymnasium>=1.0.0` added to `[project.dependencies]` in `pyproject.toml`.
+
+**Public API:** `SimulatteEnv` class, re-exported from `src/simulatte/experimental/__init__.py`.
+
+## ABC Interface
+
+```python
+from abc import ABC, abstractmethod
+from typing import Any
+
+import gymnasium
+import numpy as np
+
+
+class SimulatteEnv(gymnasium.Env, ABC):
+
+    @abstractmethod
+    def setup(self, *, seed: int | None, options: dict[str, Any] | None) -> None:
+        """Create and configure the simulation from scratch.
+
+        Called at the beginning of each episode. Must set up all simulation
+        state (environment, servers, jobs, etc.) needed for the episode.
+        """
+
+    @abstractmethod
+    def get_observation(self) -> Any:
+        """Extract the current observation from the simulation state."""
+
+    @abstractmethod
+    def apply_action(self, action: Any) -> dict[str, Any]:
+        """Apply the agent's action and advance the simulation to the next decision point.
+
+        Returns the info dict for this step.
+        """
+
+    @abstractmethod
+    def compute_reward(self) -> float:
+        """Compute the reward for the current step."""
+
+    @abstractmethod
+    def is_terminated(self) -> bool:
+        """Whether the episode ended naturally (e.g., all jobs processed)."""
+
+    @abstractmethod
+    def is_truncated(self) -> bool:
+        """Whether the episode was cut short (e.g., time budget exceeded)."""
+```
+
+## Lifecycle Orchestration
+
+The base class implements `reset()` and `step()`:
+
+```python
+    def reset(self, *, seed: int | None = None, options: dict[str, Any] | None = None):
+        super().reset(seed=seed, options=options)
+        self.setup(seed=seed, options=options)
+        return self.get_observation(), {}
+
+    def step(self, action: Any):
+        info = self.apply_action(action)
+        obs = self.get_observation()
+        reward = self.compute_reward()
+        terminated = self.is_terminated()
+        truncated = self.is_truncated()
+        return obs, reward, terminated, truncated, info
+```
+
+**Call order in `step()`:** action first (advances simulation), then observe the resulting state, then evaluate reward and termination on the new state.
+
+**`super().reset()`** is called first in `reset()` as required by Gymnasium — this handles internal `self.np_random` seeding.
+
+**`reset()` info dict** is always empty. If setup diagnostics are needed later, `setup()` can be changed to return an optional dict.
+
+## Usage Example
+
+A job-release control environment:
+
+```python
+import numpy as np
+from gymnasium import spaces
+from simulatte.experimental.gymnasium import SimulatteEnv
+from simulatte.environment import Environment
+from simulatte.shopfloor import ShopFloor
+from simulatte.server import Server
+from simulatte.psp import PSP
+
+
+class JobReleaseEnv(SimulatteEnv):
+    def __init__(self):
+        super().__init__()
+        self.observation_space = spaces.Box(
+            low=0, high=np.inf, shape=(10,), dtype=np.float64
+        )
+        self.action_space = spaces.Discrete(2)  # release or hold
+
+    def setup(self, *, seed, options):
+        self.sim_env = Environment()
+        rng = np.random.default_rng(seed)
+        self.shopfloor = ShopFloor(env=self.sim_env)
+        self.servers = [
+            Server(env=self.sim_env, capacity=1, shopfloor=self.shopfloor)
+            for _ in range(5)
+        ]
+        self.psp = PSP(env=self.sim_env, shopfloor=self.shopfloor)
+
+    def apply_action(self, action):
+        if action == 1 and len(self.psp) > 0:
+            self.psp.release(self.psp.jobs[0])
+        self.sim_env.run(until=self.sim_env.now + 10)
+        return {}
+
+    def get_observation(self):
+        obs = []
+        for server in self.servers:
+            obs.extend([len(server.queue), server.utilization_rate])
+        return np.array(obs, dtype=np.float64)
+
+    def compute_reward(self):
+        return -sum(job.lateness for job in self.shopfloor.jobs_done[-5:] if job.late)
+
+    def is_terminated(self):
+        return len(self.shopfloor.jobs_done) >= 100
+
+    def is_truncated(self):
+        return self.sim_env.now > 10_000
+```
+
+## Testing Strategy
+
+Tests live in `tests/experimental/test_gymnasium.py`. Three levels:
+
+1. **Contract tests** — A minimal concrete subclass with trivial implementations. Verify correct call order, return types and shapes, and that `super().reset()` is called.
+2. **Gymnasium compliance** — Run `gymnasium.utils.env_checker.check_env()` on the minimal subclass. This validates space consistency, dtype correctness, and full API compliance.
+3. **Integration test** — A small real simulatte simulation (2 servers, a handful of jobs) wrapped as a Gymnasium env, run for a few episodes. Validates the full loop with actual SimPy event processing.
+
+## Scope Boundaries
+
+**Not in scope:**
+
+- Rendering support
+- Built-in observation or reward helpers
+- `gymnasium.make()` registration machinery
+- Vectorized environment support (users use `gymnasium.vector.SyncVectorEnv` directly)
+- SimPy-Gymnasium synchronization primitives
+- Simulatte-specific imports or utilities in the base class
+
+**Future growth path (not implemented now):**
+
+- Rendering via optional `render()` override
+- Simulatte-aware utilities (metric snapshots, logging integration)
+- Synchronization primitives for event-driven decision points
+- All additive — nothing in this design blocks them

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "tabulate>=0.9.0",
     "loguru>=0.7.2",
     "tqdm>=4.67.1",
+    "gymnasium>=1.0.0",
 ]
 
 [build-system]

--- a/skills/simulatte-dev/SKILL.md
+++ b/skills/simulatte-dev/SKILL.md
@@ -4,13 +4,14 @@ description: >
   Use when building, configuring, debugging, or running simulations with the
   Simulatte discrete-event simulation library. Trigger whenever code imports
   from `simulatte`, references Simulatte classes (Environment, ShopFloor,
-  Server, ProductionJob, Router, PreShopPool, Runner), or the user asks about
-  job-shop simulation in a Python project. Also trigger when the user mentions
-  release policies (LumsCor, SLAR, immediate release), WIP strategies,
-  workload control, dispatching rules, starvation avoidance, or multi-run
-  experiments with seed management. Even if the user just says "set up a
-  simulation" or "compare scheduling policies" in a repo that depends on
-  simulatte, use this skill.
+  Server, ProductionJob, Router, PreShopPool, Runner, SimulatteEnv), or the
+  user asks about job-shop simulation in a Python project. Also trigger when
+  the user mentions release policies (LumsCor, SLAR, immediate release), WIP
+  strategies, workload control, dispatching rules, starvation avoidance,
+  multi-run experiments with seed management, or training RL agents on
+  simulations (Gymnasium, reinforcement learning, gym environment). Even if
+  the user just says "set up a simulation", "compare scheduling policies", or
+  "train an RL agent" in a repo that depends on simulatte, use this skill.
 ---
 
 # Simulatte Development Guide
@@ -26,6 +27,8 @@ exact constructor signatures, parameter types, or configuration structures.
 > **Experimental modules** (`simulatte.experimental`) — Warehouse, AGV, and
 > MaterialCoordinator — are excluded from this guide. They are unstable and
 > subject to breaking changes. Do not use them unless the user explicitly asks.
+> The **Gymnasium wrapper** (`SimulatteEnv`) is also experimental but is
+> covered below because RL integration is a common use case.
 
 ## Understanding the request
 
@@ -37,6 +40,7 @@ Before writing code, figure out which stage the researcher is at:
 | Compare release policies               | Run multiple builders via `Runner`  |
 | Customize dispatching or hooks         | Manual composition                  |
 | Run stochastic experiments             | `Runner` with multiple seeds        |
+| Train an RL agent on a simulation      | Gymnasium wrapper section           |
 | Analyze or plot results                | Result inspection section           |
 
 ## Choosing a release policy
@@ -274,6 +278,59 @@ results = runner.run(until=10_000)
 The `builder` callable must accept `*, env` (keyword-only). The `extract_fn`
 receives the full system tuple and returns whatever metrics the researcher
 needs. Results are a list, one entry per seed, in seed order.
+
+## Gymnasium wrapper (RL integration)
+
+> **Experimental**: `SimulatteEnv` is in `simulatte.experimental` and may
+> change in future releases.
+
+`SimulatteEnv` is a thin Gymnasium ABC that wraps a simulation as a
+Gymnasium environment for RL training. Subclass it and implement six
+abstract methods — the base class handles `reset()`, `step()`, and
+`close()` lifecycle plumbing.
+
+```python
+from simulatte.experimental.gymnasium import SimulatteEnv
+from gymnasium import spaces
+import numpy as np
+
+class MyEnv(SimulatteEnv):
+    def __init__(self):
+        super().__init__()
+        self.observation_space = spaces.Box(low=0, high=np.inf, shape=(4,), dtype=np.float64)
+        self.action_space = spaces.Discrete(2)
+
+    def setup(self, *, seed, options):       # build fresh simulation
+        ...
+    def get_observation(self):               # extract state → numpy array
+        ...
+    def apply_action(self, action):          # apply action + advance sim
+        ...
+    def compute_reward(self, action):        # return float reward
+        ...
+    def is_terminated(self):                 # natural episode end?
+        ...
+    def is_truncated(self):                  # time budget exceeded?
+        ...
+```
+
+**Key points:**
+
+- `apply_action()` is where you advance the simulation (e.g.,
+  `self.sim_env.run(until=...)`). You control when the simulation pauses.
+- `compute_reward(action)` receives the action for action-dependent
+  penalties. Access simulation state via `self`.
+- `teardown()` (optional) cleans up resources between episodes. Called
+  before `setup()` on every `reset()` after the first.
+- `get_info()` (optional) returns a step info dict, called last in
+  `step()` — use it for reward decomposition or diagnostics.
+- Use `self.np_random` (seeded automatically by Gymnasium) for all
+  numpy-based randomness.
+- Lifecycle guards raise `RuntimeError` if `step()` is called before
+  `reset()` or after episode end.
+
+The wrapper works with Stable-Baselines3, CleanRL, and any
+Gymnasium-compatible RL library.
 
 ## Result inspection
 

--- a/skills/simulatte-dev/SKILL.md
+++ b/skills/simulatte-dev/SKILL.md
@@ -321,7 +321,7 @@ class MyEnv(SimulatteEnv):
 - `compute_reward(action)` receives the action for action-dependent
   penalties. Access simulation state via `self`.
 - `teardown()` (optional) cleans up resources between episodes. Called
-  before `setup()` on every `reset()` after the first.
+  before `setup()` on every `reset()` after the first, and from `close()`.
 - `get_info()` (optional) returns a step info dict, called last in
   `step()` — use it for reward decomposition or diagnostics.
 - Use `self.np_random` (seeded automatically by Gymnasium) for all

--- a/skills/simulatte-dev/references/api-reference.md
+++ b/skills/simulatte-dev/references/api-reference.md
@@ -484,3 +484,71 @@ in seed order, one entry per seed.
 Each run creates its own `Environment` (with optional per-run log file),
 seeds `random.seed(seed)`, calls `builder(env=env)`, runs `env.run(until=until)`,
 and extracts results via `extract_fn(system)`.
+
+## SimulatteEnv (Gymnasium Wrapper)
+
+> **Experimental**: Part of `simulatte.experimental`.
+
+```python
+from simulatte.experimental.gymnasium import SimulatteEnv
+```
+
+Abstract base class extending `gymnasium.Env`. Subclass it and implement:
+
+**Abstract methods (must override):**
+
+```python
+def setup(self, *, seed: int | None, options: dict[str, Any] | None) -> None:
+    """Build fresh simulation for a new episode.
+    Use self.np_random for numpy randomness. seed is also forwarded directly."""
+
+def get_observation(self) -> Any:
+    """Extract observation from simulation state. Must match observation_space."""
+
+def apply_action(self, action: Any) -> None:
+    """Apply action and advance simulation to next decision point."""
+
+def compute_reward(self, action: Any) -> float:
+    """Compute step reward. Receives the action for action-dependent costs."""
+
+def is_terminated(self) -> bool:
+    """Whether the episode ended naturally (e.g., all jobs processed)."""
+
+def is_truncated(self) -> bool:
+    """Whether the episode was cut short (e.g., time budget exceeded)."""
+```
+
+**Optional hooks (have safe defaults):**
+
+```python
+def teardown(self) -> None:
+    """Clean up resources. Called before setup() on re-resets and from close()."""
+
+def get_info(self) -> dict[str, Any]:
+    """Return step info dict. Called last in step(). Default: {}."""
+```
+
+**Lifecycle methods (implemented by base class):**
+
+```python
+def reset(self, *, seed=None, options=None) -> tuple[obs, info]:
+    # Calls: super().reset() -> teardown() (if not first) -> setup() -> get_observation()
+
+def step(self, action) -> tuple[obs, reward, terminated, truncated, info]:
+    # Calls: apply_action() -> get_observation() -> compute_reward() -> is_terminated()
+    #        -> is_truncated() -> get_info()
+    # Raises RuntimeError if called before reset() or after episode end.
+
+def close(self) -> None:
+    # Calls teardown() if initialized, then super().close()
+```
+
+**State tracking (class-level defaults, shadowed per-instance):**
+
+- `_is_initialized: bool = False` — set True after first `setup()`
+- `_done: bool = False` — set True when `is_terminated()` or `is_truncated()` returns True
+
+**Subclass `__init__` must set:**
+
+- `self.observation_space: gymnasium.spaces.Space`
+- `self.action_space: gymnasium.spaces.Space`

--- a/skills/simulatte-dev/references/api-reference.md
+++ b/skills/simulatte-dev/references/api-reference.md
@@ -531,10 +531,14 @@ def get_info(self) -> dict[str, Any]:
 **Lifecycle methods (implemented by base class):**
 
 ```python
-def reset(self, *, seed=None, options=None) -> tuple[obs, info]:
+def reset(
+    self, *, seed: int | None = None, options: dict[str, Any] | None = None,
+) -> tuple[Any, dict[str, Any]]:
     # Calls: super().reset() -> teardown() (if not first) -> setup() -> get_observation()
+    # Always returns (observation, {}). Does NOT call get_info().
 
-def step(self, action) -> tuple[obs, reward, terminated, truncated, info]:
+def step(self, action: Any) -> tuple[Any, float, bool, bool, dict[str, Any]]:
+    # Returns: (obs, reward, terminated, truncated, info)
     # Calls: apply_action() -> get_observation() -> compute_reward() -> is_terminated()
     #        -> is_truncated() -> get_info()
     # Raises RuntimeError if called before reset() or after episode end.

--- a/src/simulatte/experimental/__init__.py
+++ b/src/simulatte/experimental/__init__.py
@@ -9,6 +9,7 @@ Exports:
     MaterialCoordinator: Orchestrates material delivery with FIFO blocking.
     MaterialSystem: Type alias for material handling system tuple.
     MaterialSystemBuilder: Factory for building material handling systems.
+    SimulatteEnv: Gymnasium environment base class for RL integration.
     TransportJob: Job type for AGV transport operations.
     Warehouse: Warehouse server with inventory containers.
     WarehouseJob: Job type for warehouse pick/put operations.
@@ -18,6 +19,7 @@ from __future__ import annotations
 
 from simulatte.experimental.agv import AGV
 from simulatte.experimental.builders import MaterialSystemBuilder
+from simulatte.experimental.gymnasium import SimulatteEnv
 from simulatte.experimental.job import TransportJob, WarehouseJob
 from simulatte.experimental.materials import MaterialCoordinator
 from simulatte.experimental.typing import MaterialSystem
@@ -28,6 +30,7 @@ __all__ = [
     "MaterialCoordinator",
     "MaterialSystem",
     "MaterialSystemBuilder",
+    "SimulatteEnv",
     "TransportJob",
     "Warehouse",
     "WarehouseJob",

--- a/src/simulatte/experimental/gymnasium.py
+++ b/src/simulatte/experimental/gymnasium.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+import gymnasium
+
+
+class SimulatteEnv(gymnasium.Env, ABC):
+    """Base class for wrapping simulations as Gymnasium environments.
+
+    Subclass this and implement the six abstract methods to define your
+    simulation's observation space, action space, setup, reward, and
+    termination logic. The base class handles Gymnasium lifecycle
+    orchestration, state tracking, and resource cleanup.
+
+    Two optional hooks are available:
+    - ``teardown()``: clean up simulation resources between episodes.
+    - ``get_info()``: return step metadata after all computations.
+
+    Subclasses must set ``observation_space`` and ``action_space`` in
+    ``__init__`` before calling ``reset()``.
+    """
+
+    _is_initialized: bool = False
+    _done: bool = False
+
+    @abstractmethod
+    def setup(self, *, seed: int | None, options: dict[str, Any] | None) -> None:
+        """Create and configure the simulation from scratch.
+
+        Called at the beginning of each episode. Must set up all simulation
+        state needed for the episode.
+
+        For numpy-based randomness, prefer ``self.np_random`` — it is
+        automatically seeded by Gymnasium and persists correctly across
+        unseeded resets.
+        """
+
+    @abstractmethod
+    def get_observation(self) -> Any:
+        """Extract the current observation from the simulation state."""
+
+    @abstractmethod
+    def apply_action(self, action: Any) -> None:
+        """Apply the agent's action and advance the simulation to the next decision point."""
+
+    @abstractmethod
+    def compute_reward(self, action: Any) -> float:
+        """Compute the reward for the current step."""
+
+    @abstractmethod
+    def is_terminated(self) -> bool:
+        """Whether the episode ended naturally."""
+
+    @abstractmethod
+    def is_truncated(self) -> bool:
+        """Whether the episode was cut short."""
+
+    def teardown(self) -> None:
+        """Clean up simulation resources from the previous episode.
+
+        Called before ``setup()`` on every ``reset()`` after the first,
+        and from ``close()``.
+        """
+
+    def get_info(self) -> dict[str, Any]:
+        """Return the info dict for this step.
+
+        Called last in ``step()``, after observation, reward, and
+        termination have all been computed.
+        """
+        return {}
+
+    def reset(
+        self,
+        *,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[Any, dict[str, Any]]:
+        super().reset(seed=seed, options=options)
+        if self._is_initialized:
+            self.teardown()
+        self.setup(seed=seed, options=options)
+        self._is_initialized = True
+        self._done = False
+        return self.get_observation(), {}
+
+    def step(self, action: Any) -> tuple[Any, float, bool, bool, dict[str, Any]]:
+        if not self._is_initialized or self._done:
+            msg = "Cannot call step() before reset() or after episode end. Call reset() first."
+            raise RuntimeError(msg)
+        self.apply_action(action)
+        obs = self.get_observation()
+        reward = self.compute_reward(action)
+        terminated = self.is_terminated()
+        truncated = self.is_truncated()
+        if terminated or truncated:
+            self._done = True
+        info = self.get_info()
+        return obs, reward, terminated, truncated, info
+
+    def close(self) -> None:
+        if self._is_initialized:
+            self.teardown()
+            self._is_initialized = False
+        super().close()

--- a/tests/experimental/test_gymnasium.py
+++ b/tests/experimental/test_gymnasium.py
@@ -241,3 +241,13 @@ class TestSeededDeterminism:
         obs_2, _ = self._collect_trajectory(env, seed=99, actions=actions)
         any_different = any(not np.array_equal(o1, o2) for o1, o2 in zip(obs_1, obs_2, strict=True))
         assert any_different
+
+
+class TestGymnasiumCompliance:
+    """Run Gymnasium's built-in env checker for baseline API compliance."""
+
+    def test_check_env_passes(self) -> None:
+        from gymnasium.utils.env_checker import check_env
+
+        env = MinimalEnv()
+        check_env(env.unwrapped, skip_render_check=True)

--- a/tests/experimental/test_gymnasium.py
+++ b/tests/experimental/test_gymnasium.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from gymnasium import spaces
+
+from simulatte.experimental.gymnasium import SimulatteEnv
+
+
+class MinimalEnv(SimulatteEnv):
+    """Minimal concrete subclass for testing the base class contract."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.observation_space = spaces.Box(low=0.0, high=1.0, shape=(2,), dtype=np.float64)
+        self.action_space = spaces.Discrete(2)
+        self.step_count = 0
+        self.max_steps = 3
+        self.setup_calls: list[int | None] = []
+        self.teardown_calls: int = 0
+
+    def setup(self, *, seed: int | None, options: dict | None) -> None:
+        self.step_count = 0
+        self.setup_calls.append(seed)
+
+    def teardown(self) -> None:
+        self.teardown_calls += 1
+
+    def get_observation(self):
+        return np.array([0.5, 0.5], dtype=np.float64)
+
+    def apply_action(self, action) -> None:
+        self.step_count += 1
+
+    def compute_reward(self, action) -> float:
+        return 1.0
+
+    def is_terminated(self) -> bool:
+        return self.step_count >= self.max_steps
+
+    def is_truncated(self) -> bool:
+        return False
+
+
+class TestLifecycleGuards:
+    """Verify that step() raises RuntimeError in invalid states."""
+
+    def test_step_before_reset_raises(self) -> None:
+        env = MinimalEnv()
+        with pytest.raises(RuntimeError, match="Call reset\\(\\) first"):
+            env.step(0)
+
+    def test_step_after_terminated_raises(self) -> None:
+        env = MinimalEnv()
+        env.max_steps = 1
+        env.reset(seed=42)
+        _, _, terminated, _, _ = env.step(0)
+        assert terminated
+        with pytest.raises(RuntimeError, match="Call reset\\(\\) first"):
+            env.step(0)
+
+    def test_step_after_truncated_raises(self) -> None:
+        env = MinimalEnv()
+        env.reset(seed=42)
+        # Override is_truncated to return True on first step
+        env.is_truncated = lambda: True  # type: ignore[assignment]
+        _, _, _, truncated, _ = env.step(0)
+        assert truncated
+        with pytest.raises(RuntimeError, match="Call reset\\(\\) first"):
+            env.step(0)
+
+
+class TestResetLifecycle:
+    """Verify reset/teardown call ordering."""
+
+    def test_first_reset_does_not_call_teardown(self) -> None:
+        env = MinimalEnv()
+        env.reset(seed=42)
+        assert env.teardown_calls == 0
+        assert env.setup_calls == [42]
+
+    def test_second_reset_calls_teardown_before_setup(self) -> None:
+        env = MinimalEnv()
+        env.reset(seed=1)
+        env.reset(seed=2)
+        assert env.teardown_calls == 1
+        assert env.setup_calls == [1, 2]
+
+    def test_reset_after_done_resets_lifecycle(self) -> None:
+        env = MinimalEnv()
+        env.max_steps = 1
+        env.reset(seed=10)
+        env.step(0)  # terminates
+        env.reset(seed=20)  # should work, not raise
+        obs, _ = env.reset(seed=30)
+        assert obs is not None
+
+
+class TestCloseLifecycle:
+    """Verify close() teardown behavior."""
+
+    def test_close_without_reset_does_not_call_teardown(self) -> None:
+        env = MinimalEnv()
+        env.close()
+        assert env.teardown_calls == 0
+
+    def test_close_after_reset_calls_teardown(self) -> None:
+        env = MinimalEnv()
+        env.reset(seed=42)
+        env.close()
+        assert env.teardown_calls == 1
+
+    def test_close_then_step_raises(self) -> None:
+        env = MinimalEnv()
+        env.reset(seed=42)
+        env.close()
+        with pytest.raises(RuntimeError, match="Call reset\\(\\) first"):
+            env.step(0)
+
+
+class TestStepCallOrder:
+    """Verify step() returns correct 5-tuple in correct order."""
+
+    def test_step_returns_five_tuple(self) -> None:
+        env = MinimalEnv()
+        env.reset(seed=42)
+        result = env.step(0)
+        assert len(result) == 5
+        obs, reward, terminated, truncated, info = result
+        assert isinstance(obs, np.ndarray)
+        assert isinstance(reward, float)
+        assert isinstance(terminated, bool)
+        assert isinstance(truncated, bool)
+        assert isinstance(info, dict)
+
+    def test_reset_returns_obs_and_info(self) -> None:
+        env = MinimalEnv()
+        result = env.reset(seed=42)
+        assert len(result) == 2
+        obs, info = result
+        assert isinstance(obs, np.ndarray)
+        assert isinstance(info, dict)
+
+
+class TestGetInfo:
+    """Verify get_info() is called and its return is used."""
+
+    def test_default_get_info_returns_empty_dict(self) -> None:
+        env = MinimalEnv()
+        env.reset(seed=42)
+        _, _, _, _, info = env.step(0)
+        assert info == {}
+
+    def test_custom_get_info_is_used(self) -> None:
+        class InfoEnv(MinimalEnv):
+            def get_info(self):
+                return {"step": self.step_count}
+
+        env = InfoEnv()
+        env.reset(seed=42)
+        _, _, _, _, info = env.step(0)
+        assert info == {"step": 1}
+
+
+class TestComputeRewardReceivesAction:
+    """Verify compute_reward() receives the action passed to step()."""
+
+    def test_reward_receives_action(self) -> None:
+        class ActionRewardEnv(MinimalEnv):
+            def compute_reward(self, action) -> float:
+                return -10.0 if action == 1 else 0.0
+
+        env = ActionRewardEnv()
+        env.reset(seed=42)
+        _, reward_0, _, _, _ = env.step(0)
+        assert reward_0 == 0.0
+
+        env.reset(seed=42)
+        _, reward_1, _, _, _ = env.step(1)
+        assert reward_1 == -10.0

--- a/tests/experimental/test_gymnasium.py
+++ b/tests/experimental/test_gymnasium.py
@@ -18,13 +18,16 @@ class MinimalEnv(SimulatteEnv):
         self.max_steps = 3
         self.setup_calls: list[int | None] = []
         self.teardown_calls: int = 0
+        self.call_log: list[str] = []
 
     def setup(self, *, seed: int | None, options: dict | None) -> None:
         self.step_count = 0
         self.setup_calls.append(seed)
+        self.call_log.append("setup")
 
     def teardown(self) -> None:
         self.teardown_calls += 1
+        self.call_log.append("teardown")
 
     def get_observation(self):
         return np.array([0.5, 0.5], dtype=np.float64)
@@ -82,9 +85,11 @@ class TestResetLifecycle:
     def test_second_reset_calls_teardown_before_setup(self) -> None:
         env = MinimalEnv()
         env.reset(seed=1)
+        env.call_log.clear()
         env.reset(seed=2)
         assert env.teardown_calls == 1
         assert env.setup_calls == [1, 2]
+        assert env.call_log == ["teardown", "setup"]
 
     def test_reset_after_done_resets_lifecycle(self) -> None:
         env = MinimalEnv()
@@ -92,8 +97,9 @@ class TestResetLifecycle:
         env.reset(seed=10)
         env.step(0)  # terminates
         env.reset(seed=20)  # should work, not raise
-        obs, _ = env.reset(seed=30)
-        assert obs is not None
+        obs, reward, terminated, truncated, info = env.step(0)  # should work after re-reset
+        assert isinstance(obs, np.ndarray)
+        assert terminated  # max_steps=1, so one step terminates
 
 
 class TestCloseLifecycle:
@@ -331,45 +337,54 @@ class TestSimulatteIntegration:
         assert obs.shape == (4,)
         assert info == {}
 
-        done = False
+        terminated = False
+        truncated = False
         steps = 0
-        while not done:
+        while not (terminated or truncated):
             action = 1 if obs[3] > 0 else 0  # release if pending jobs remain
             obs, reward, terminated, truncated, info = env.step(action)
-            done = terminated or truncated
             steps += 1
 
         assert steps > 0
-        assert len(env.shopfloor.jobs_done) > 0
+        assert terminated
+        assert not truncated
+        assert len(env.shopfloor.jobs_done) == env.total_jobs
         env.close()
 
     def test_multiple_episodes_with_teardown(self) -> None:
         env = SimulatteIntegrationEnv()
+        sim_envs_seen = []
         for seed in [1, 2, 3]:
             obs, _ = env.reset(seed=seed)
+            sim_envs_seen.append(id(env.sim_env))
             for _ in range(3):
                 obs, _, terminated, truncated, _ = env.step(1)
                 if terminated or truncated:
                     break
+        # Each episode should create a fresh sim environment
+        assert len(set(sim_envs_seen)) == 3
         env.close()
 
     def test_deterministic_episodes(self) -> None:
         env = SimulatteIntegrationEnv()
 
-        def run_episode(seed: int) -> list:
+        def run_episode(seed: int) -> tuple[list, list]:
             obs_list = []
+            reward_list = []
             obs, _ = env.reset(seed=seed)
             obs_list.append(obs.copy())
             for _ in range(5):
-                obs, _, terminated, truncated, _ = env.step(1)
+                obs, reward, terminated, truncated, _ = env.step(1)
                 obs_list.append(obs.copy())
+                reward_list.append(reward)
                 if terminated or truncated:
                     break
-            return obs_list
+            return obs_list, reward_list
 
-        traj_1 = run_episode(seed=42)
-        traj_2 = run_episode(seed=42)
-        for o1, o2 in zip(traj_1, traj_2, strict=True):
+        obs_1, rew_1 = run_episode(seed=42)
+        obs_2, rew_2 = run_episode(seed=42)
+        for o1, o2 in zip(obs_1, obs_2, strict=True):
             np.testing.assert_array_equal(o1, o2)
+        assert rew_1 == rew_2
 
         env.close()

--- a/tests/experimental/test_gymnasium.py
+++ b/tests/experimental/test_gymnasium.py
@@ -251,3 +251,125 @@ class TestGymnasiumCompliance:
 
         env = MinimalEnv()
         check_env(env.unwrapped, skip_render_check=True)
+
+
+class SimulatteIntegrationEnv(SimulatteEnv):
+    """A real simulatte simulation wrapped as a Gymnasium environment."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.observation_space = spaces.Box(low=0.0, high=np.inf, shape=(4,), dtype=np.float64)
+        self.action_space = spaces.Discrete(2)
+
+    def setup(self, *, seed: int | None, options: dict | None) -> None:
+        from simulatte.environment import Environment
+        from simulatte.server import Server
+        from simulatte.shopfloor import ShopFloor
+
+        self.sim_env = Environment()
+        self.shopfloor = ShopFloor(env=self.sim_env)
+        self.servers = [
+            Server(env=self.sim_env, capacity=1, shopfloor=self.shopfloor),
+            Server(env=self.sim_env, capacity=1, shopfloor=self.shopfloor),
+        ]
+        self.jobs_released = 0
+        self.total_jobs = 5
+        self._rng = self.np_random
+        self._create_pending_jobs()
+
+    def _create_pending_jobs(self) -> None:
+        from simulatte.job import ProductionJob
+
+        self._pending_jobs = [
+            ProductionJob(
+                env=self.sim_env,
+                sku="A",
+                servers=self.servers,
+                processing_times=[self._rng.uniform(1.0, 5.0), self._rng.uniform(1.0, 5.0)],
+                due_date=50.0,
+            )
+            for _ in range(self.total_jobs)
+        ]
+
+    def teardown(self) -> None:
+        self.sim_env.close()
+
+    def apply_action(self, action) -> None:
+        if action == 1 and self._pending_jobs:
+            job = self._pending_jobs.pop(0)
+            self.shopfloor.add(job)
+            self.jobs_released += 1
+        self.sim_env.run(until=self.sim_env.now + 5.0)
+
+    def get_observation(self):
+        return np.array(
+            [
+                len(self.servers[0].queue),
+                len(self.servers[1].queue),
+                self.sim_env.now,
+                len(self._pending_jobs),
+            ],
+            dtype=np.float64,
+        )
+
+    def compute_reward(self, action) -> float:
+        return -sum(1.0 for job in self.shopfloor.jobs_done if job.late)
+
+    def is_terminated(self) -> bool:
+        return len(self.shopfloor.jobs_done) >= self.total_jobs
+
+    def is_truncated(self) -> bool:
+        return self.sim_env.now > 200.0
+
+
+class TestSimulatteIntegration:
+    """Integration test using real simulatte simulation components."""
+
+    def test_full_episode(self) -> None:
+        env = SimulatteIntegrationEnv()
+        obs, info = env.reset(seed=42)
+        assert obs.shape == (4,)
+        assert info == {}
+
+        done = False
+        steps = 0
+        while not done:
+            action = 1 if obs[3] > 0 else 0  # release if pending jobs remain
+            obs, reward, terminated, truncated, info = env.step(action)
+            done = terminated or truncated
+            steps += 1
+
+        assert steps > 0
+        assert len(env.shopfloor.jobs_done) > 0
+        env.close()
+
+    def test_multiple_episodes_with_teardown(self) -> None:
+        env = SimulatteIntegrationEnv()
+        for seed in [1, 2, 3]:
+            obs, _ = env.reset(seed=seed)
+            for _ in range(3):
+                obs, _, terminated, truncated, _ = env.step(1)
+                if terminated or truncated:
+                    break
+        env.close()
+
+    def test_deterministic_episodes(self) -> None:
+        env = SimulatteIntegrationEnv()
+
+        def run_episode(seed: int) -> list:
+            obs_list = []
+            obs, _ = env.reset(seed=seed)
+            obs_list.append(obs.copy())
+            for _ in range(5):
+                obs, _, terminated, truncated, _ = env.step(1)
+                obs_list.append(obs.copy())
+                if terminated or truncated:
+                    break
+            return obs_list
+
+        traj_1 = run_episode(seed=42)
+        traj_2 = run_episode(seed=42)
+        for o1, o2 in zip(traj_1, traj_2, strict=True):
+            np.testing.assert_array_equal(o1, o2)
+
+        env.close()

--- a/tests/experimental/test_gymnasium.py
+++ b/tests/experimental/test_gymnasium.py
@@ -178,3 +178,66 @@ class TestComputeRewardReceivesAction:
         env.reset(seed=42)
         _, reward_1, _, _, _ = env.step(1)
         assert reward_1 == -10.0
+
+
+class StochasticEnv(SimulatteEnv):
+    """Subclass that uses self.np_random to produce stochastic observations."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.observation_space = spaces.Box(low=0.0, high=100.0, shape=(1,), dtype=np.float64)
+        self.action_space = spaces.Discrete(2)
+        self.step_count = 0
+
+    def setup(self, *, seed: int | None, options: dict | None) -> None:
+        self.step_count = 0
+
+    def get_observation(self):
+        return np.array([self.np_random.uniform(0.0, 100.0)], dtype=np.float64)
+
+    def apply_action(self, action) -> None:
+        self.step_count += 1
+
+    def compute_reward(self, action) -> float:
+        return self.np_random.uniform(-1.0, 1.0)
+
+    def is_terminated(self) -> bool:
+        return self.step_count >= 5
+
+    def is_truncated(self) -> bool:
+        return False
+
+
+class TestSeededDeterminism:
+    """Verify that seeding produces reproducible trajectories."""
+
+    @staticmethod
+    def _collect_trajectory(env: StochasticEnv, seed: int, actions: list[int]) -> tuple[list, list]:
+        observations = []
+        rewards = []
+        obs, _ = env.reset(seed=seed)
+        observations.append(obs.copy())
+        for action in actions:
+            obs, reward, terminated, truncated, _ = env.step(action)
+            observations.append(obs.copy())
+            rewards.append(reward)
+            if terminated or truncated:
+                break
+        return observations, rewards
+
+    def test_same_seed_same_trajectory(self) -> None:
+        env = StochasticEnv()
+        actions = [0, 1, 0, 1, 0]
+        obs_1, rew_1 = self._collect_trajectory(env, seed=42, actions=actions)
+        obs_2, rew_2 = self._collect_trajectory(env, seed=42, actions=actions)
+        for o1, o2 in zip(obs_1, obs_2, strict=True):
+            np.testing.assert_array_equal(o1, o2)
+        assert rew_1 == rew_2
+
+    def test_different_seed_different_trajectory(self) -> None:
+        env = StochasticEnv()
+        actions = [0, 1, 0, 1, 0]
+        obs_1, _ = self._collect_trajectory(env, seed=42, actions=actions)
+        obs_2, _ = self._collect_trajectory(env, seed=99, actions=actions)
+        any_different = any(not np.array_equal(o1, o2) for o1, o2 in zip(obs_1, obs_2, strict=True))
+        assert any_different

--- a/uv.lock
+++ b/uv.lock
@@ -24,6 +24,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -200,6 +209,15 @@ wheels = [
 ]
 
 [[package]]
+name = "farama-notifications"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/91/14397890dde30adc4bee6462158933806207bc5dd10d7b4d09d5c33845cf/farama_notifications-0.0.6.tar.gz", hash = "sha256:b19acac4bb41d76e59e03394b5dd165f4761c86fa327f56307a35cbee3b60158", size = 2517, upload-time = "2026-04-24T08:43:57.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/f0/21f81892e4ed10f4ec3ef2e7cf8635fb76e7c0907c55d0da66be50094760/farama_notifications-0.0.6-py3-none-any.whl", hash = "sha256:f84839188efa1ce5bb361c2a84881b2dc2c0d0d7fb661ff00421820170930935", size = 2897, upload-time = "2026-04-24T08:43:56.785Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -247,6 +265,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6f/9a/3b536bad3be4f26186f296e749ff17bad3e6d57232c104d752d24b2e265b/fonttools-4.61.0-cp314-cp314t-win32.whl", hash = "sha256:63c7125d31abe3e61d7bb917329b5543c5b3448db95f24081a13aaf064360fc8", size = 2330707, upload-time = "2025-11-28T17:05:43.548Z" },
     { url = "https://files.pythonhosted.org/packages/18/ea/e6b9ac610451ee9f04477c311ad126de971f6112cb579fa391d2a8edb00b/fonttools-4.61.0-cp314-cp314t-win_amd64.whl", hash = "sha256:67d841aa272be5500de7f447c40d1d8452783af33b4c3599899319f6ef9ad3c1", size = 2395950, upload-time = "2025-11-28T17:05:45.638Z" },
     { url = "https://files.pythonhosted.org/packages/0c/14/634f7daea5ffe6a5f7a0322ba8e1a0e23c9257b80aa91458107896d1dfc7/fonttools-4.61.0-py3-none-any.whl", hash = "sha256:276f14c560e6f98d24ef7f5f44438e55ff5a67f78fa85236b218462c9f5d0635", size = 1144485, upload-time = "2025-11-28T17:05:47.573Z" },
+]
+
+[[package]]
+name = "gymnasium"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "farama-notifications" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/ff/14b6880d703dfaca204490979d3254ccd280c99550798993319902873658/gymnasium-1.3.0.tar.gz", hash = "sha256:6939e86e835d6b71b6ba6bfd360487420876deafc79bfb7bacba83a7c446bcf3", size = 830646, upload-time = "2026-04-22T13:47:14.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/73/fda6a25f3beeb5e49d74330b44092b9e5a547395ccd478d1103ddcbff1fc/gymnasium-1.3.0-py3-none-any.whl", hash = "sha256:6b8c159a8540dcbcb221722d7efda24d78ebbcbc3bd2ea1c2611aa2a34471fc2", size = 953904, upload-time = "2026-04-22T13:47:12.13Z" },
 ]
 
 [[package]]
@@ -758,6 +791,7 @@ name = "simulatte"
 version = "0.4.0"
 source = { editable = "." }
 dependencies = [
+    { name = "gymnasium" },
     { name = "loguru" },
     { name = "matplotlib" },
     { name = "simpy" },
@@ -778,6 +812,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "gymnasium", specifier = ">=1.0.0" },
     { name = "loguru", specifier = ">=0.7.2" },
     { name = "matplotlib", specifier = ">=3.7.2" },
     { name = "simpy", specifier = ">=4.0.1" },
@@ -849,6 +884,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/47/fd58e80a3e42310b4b649340d5d97403fe796146cae8678b3a031a414b8e/ty-0.0.1a32-py3-none-win32.whl", hash = "sha256:f55ec25088a09236ad1578b656a07fa009c3a353f5923486905ba48175d142a6", size = 9077703, upload-time = "2025-12-05T21:04:15.849Z" },
     { url = "https://files.pythonhosted.org/packages/8d/96/209c417c69317339ea8e9b3277fd98364a0e97dd1ffd3585e143ec7b4e57/ty-0.0.1a32-py3-none-win_amd64.whl", hash = "sha256:ed8d5cbd4e47dfed86aaa27e243008aa4e82b6a5434f3ab95c26d3ee5874d9d7", size = 9922426, upload-time = "2025-12-05T21:04:33.289Z" },
     { url = "https://files.pythonhosted.org/packages/e0/1c/350fd851fb91244f8c80cec218009cbee7564d76c14e2f423b47e69a5cbc/ty-0.0.1a32-py3-none-win_arm64.whl", hash = "sha256:dbb25f9b513d34cee8ce419514eaef03313f45c3f7ab4eb6e6d427ea1f6854af", size = 9453761, upload-time = "2025-12-05T21:04:24.502Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]

--- a/zensical.toml
+++ b/zensical.toml
@@ -21,6 +21,7 @@ nav = [
   { "Agent Skill" = "ai-skill.md" },
   { "Experimental" = [
     { "Overview" = "experimental/index.md" },
+    { "Gymnasium wrapper for RL" = "experimental/gymnasium-wrapper.md" },
     { "Materials, warehouse, and AGVs" = "experimental/materials-warehouse-agvs.md" },
   ]},
 ]


### PR DESCRIPTION
## Summary

Adds `SimulatteEnv`, a thin Gymnasium ABC that lets developers wrap simulatte simulations as Gymnasium environments for training RL agents.

## What's included

### Implementation
- **`src/simulatte/experimental/gymnasium.py`** — `SimulatteEnv` base class (~107 lines, 100% branch coverage)
  - 6 abstract methods: `setup()`, `get_observation()`, `apply_action()`, `compute_reward(action)`, `is_terminated()`, `is_truncated()`
  - 2 optional hooks: `teardown()` (resource cleanup), `get_info()` (step metadata, called last)
  - Lifecycle guards: `RuntimeError` on `step()` before `reset()` or after episode end
  - Seeding: `self.np_random` recommended, raw `seed` also forwarded
  - Framework-agnostic: no simulatte-specific imports in the base class
- **`pyproject.toml`** — `gymnasium>=1.0.0` added as required dependency
- **`src/simulatte/experimental/__init__.py`** — re-exports `SimulatteEnv`

### Tests (`tests/experimental/test_gymnasium.py`)
- Contract tests: lifecycle guards, reset/teardown ordering, step return types
- Gymnasium compliance: `check_env()` baseline validation
- Seeded determinism: same seed + same actions = same trajectory
- Integration: real simulatte simulation (ShopFloor, Servers, ProductionJobs) wrapped and run for multiple episodes

### Documentation
- **`docs/experimental/gymnasium-wrapper.md`** — user-facing page with working example, method reference, seeding guide
- **`docs/ai-skill.md`** — updated to reflect Gymnasium wrapper coverage
- **`skills/simulatte-dev/SKILL.md`** — new Gymnasium wrapper section, updated triggers and decision table
- **`skills/simulatte-dev/references/api-reference.md`** — full `SimulatteEnv` API reference
- **`CLAUDE.md`** and **`README.md`** — updated with new feature

## Design spec

`docs/superpowers/specs/2026-04-29-gymnasium-wrapper-design.md`

## Verification

- 339 tests pass
- Coverage: 99.14% (gymnasium.py at 100%)
- ruff, ty: clean
- Docs build: clean
- Two rounds of adversarial review (implementation + documentation) via Codex
