### PR TITLE
fix(logger): defer finalizer handler removal to avoid loguru lock self-deadlock

### DIFF
--- a/src/simulatte/logger.py
+++ b/src/simulatte/logger.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import sqlite3
 import sys
@@ -20,6 +21,51 @@ from loguru import logger as _logger
 
 if TYPE_CHECKING:
     from simulatte.environment import Environment
+
+
+# --- loguru handler-removal re-entrancy guard --------------------------------
+# Loguru's ``_core.lock`` is a non-reentrant lock held during ``add()``/``remove()``.
+# A SimLogger weakref finalizer may fire (via GC) on a thread that is already inside
+# one of those calls; removing a handler then re-acquires the same lock on the same
+# thread and self-deadlocks — notably on PyPy, whose cyclic GC runs finalizers at
+# arbitrary points. While a thread is inside such a section we defer handler removals
+# to a queue, drained once the lock is free again.
+_loguru_critical = threading.local()
+_pending_handler_removals: deque[int] = deque()
+
+
+def _in_loguru_critical_section() -> bool:
+    """Whether the current thread is inside a loguru ``add()``/``remove()`` call."""
+    return getattr(_loguru_critical, "active", False)
+
+
+def _drain_pending_handler_removals() -> None:
+    """Remove handlers deferred by finalizers that fired during a critical section."""
+    while True:
+        try:
+            handler_id = _pending_handler_removals.popleft()
+        except IndexError:
+            break
+        try:
+            _logger.remove(handler_id)
+        except Exception:  # pragma: no cover - handler may already be gone
+            pass
+
+
+@contextlib.contextmanager
+def _loguru_critical_section() -> Iterator[None]:
+    """Mark the current thread as inside a loguru lock-holding call.
+
+    Finalizers firing while this is active defer their handler removal instead of
+    re-entering loguru's lock. On exit (the lock is released) we drain the deferrals
+    — still flagged, so a finalizer firing mid-drain defers rather than deadlocks.
+    """
+    _loguru_critical.active = True
+    try:
+        yield
+    finally:
+        _drain_pending_handler_removals()
+        _loguru_critical.active = False
 
 
 def _patch_loguru_default_sink() -> None:
@@ -464,13 +510,14 @@ class SimLogger:
 
     def _setup_handler(self) -> None:
         """Configure loguru handler for this environment."""
-        self._handler_id = _logger.add(
-            self._make_sink(),
-            format="{message}",  # We handle formatting in the sink
-            level="TRACE",  # Accept all levels, we filter ourselves
-            filter=lambda r: r["extra"].get("env_id") == self._env_id,
-            enqueue=False,  # Our sink handles output directly
-        )
+        with _loguru_critical_section():
+            self._handler_id = _logger.add(
+                self._make_sink(),
+                format="{message}",  # We handle formatting in the sink
+                level="TRACE",  # Accept all levels, we filter ourselves
+                filter=lambda r: r["extra"].get("env_id") == self._env_id,
+                enqueue=False,  # Our sink handles output directly
+            )
 
     def _log(
         self,
@@ -616,10 +663,11 @@ class SimLogger:
         if getattr(self, "_finalizer", None) is not None and self._finalizer.alive:
             self._finalizer.detach()
         if self._handler_id is not None:
-            try:
-                _logger.remove(self._handler_id)
-            except ValueError:
-                pass  # Handler already removed
+            with _loguru_critical_section():
+                try:
+                    _logger.remove(self._handler_id)
+                except ValueError:
+                    pass  # Handler already removed
             self._handler_id = None
         store = getattr(self, "_db_store", None)
         if store is not None:
@@ -633,11 +681,17 @@ def _finalize_logger(
 ) -> None:
     """Clean up logger resources from a weakref finalizer callback."""
     if handler_id is not None:
-        try:
-            _logger.remove(handler_id)
-        except Exception:
-            # Be resilient: handler may already be removed, or Loguru may be torn down.
-            pass
+        if _in_loguru_critical_section():
+            # This thread already holds loguru's _core.lock (inside an add()/remove()).
+            # Removing now would re-enter the lock and self-deadlock; defer instead.
+            # The handler is removed when the critical section drains on exit.
+            _pending_handler_removals.append(handler_id)
+        else:
+            try:
+                _logger.remove(handler_id)
+            except Exception:
+                # Be resilient: handler may already be removed, or Loguru may be torn down.
+                pass
     if db_store is not None:
         try:
             db_store.close()

--- a/tests/core/test_logger_finalizer.py
+++ b/tests/core/test_logger_finalizer.py
@@ -1,0 +1,66 @@
+"""Regression tests for the loguru handler-removal deadlock.
+
+A weakref finalizer (``_finalize_logger``) can fire — via GC — while the same
+thread is already inside a loguru ``add()``/``remove()`` that holds loguru's
+non-reentrant ``_core.lock``. Calling ``_logger.remove()`` from the finalizer at
+that moment re-acquires the same lock on the same thread and self-deadlocks
+(observed on PyPy, where the cyclic GC fires finalizers at arbitrary points).
+
+The fix: while we are inside such a critical section, the finalizer must *defer*
+the handler removal to a queue that is drained at a safe point (lock free),
+instead of calling ``_logger.remove()`` re-entrantly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from simulatte import logger as logmod
+
+
+class _RecordingLogger:
+    """Stand-in for the module-level loguru logger that records remove() calls."""
+
+    def __init__(self) -> None:
+        self.removed: list[int] = []
+
+    def remove(self, handler_id: int) -> None:
+        self.removed.append(handler_id)
+
+
+@pytest.fixture
+def fake_logger(monkeypatch: pytest.MonkeyPatch) -> _RecordingLogger:
+    fake = _RecordingLogger()
+    monkeypatch.setattr(logmod, "_logger", fake)
+    # Start each test with a clean queue and an inactive critical-section flag.
+    logmod._pending_handler_removals.clear()
+    logmod._loguru_critical.active = False
+    return fake
+
+
+def test_finalizer_defers_handler_removal_during_loguru_critical_section(
+    fake_logger: _RecordingLogger,
+) -> None:
+    # Simulate a finalizer firing while this thread is mid-add() (lock held).
+    logmod._loguru_critical.active = True
+    try:
+        logmod._finalize_logger(handler_id=123, db_store=None)
+        # Must NOT call remove() now — that would re-enter _core.lock and deadlock.
+        assert fake_logger.removed == []
+        assert list(logmod._pending_handler_removals) == [123]
+    finally:
+        logmod._loguru_critical.active = False
+
+    # Draining at a safe point (lock free) performs the deferred removal.
+    logmod._drain_pending_handler_removals()
+    assert fake_logger.removed == [123]
+    assert len(logmod._pending_handler_removals) == 0
+
+
+def test_finalizer_removes_handler_directly_outside_critical_section(
+    fake_logger: _RecordingLogger,
+) -> None:
+    # No critical section active: removing directly is safe (lock uncontended).
+    logmod._finalize_logger(handler_id=456, db_store=None)
+    assert fake_logger.removed == [456]
+    assert len(logmod._pending_handler_removals) == 0


### PR DESCRIPTION
## Summary

Fixes the intermittent CI deadlock where the test suite hangs to the 20-min runner cap — most often on the **PyPy 3.11** lane, but observed across all interpreters and on unrelated (pre-existing) runs.

**Root cause.** `SimLogger`'s weakref finalizer `_finalize_logger` calls loguru's `remove()`, which acquires loguru's non-reentrant `_core.lock`. `Environment` and `SimLogger` form a **reference cycle** (`env._logger` ↔ `logger._env`), so an orphaned `Environment` (one created without `close()`/a `with` block — e.g. the `env` test fixture) is reclaimable only by the **cyclic GC**, which runs at arbitrary points (frequently on PyPy). When that collection fires the finalizer on a thread already inside `_logger.add()` — which holds `_core.lock` through loguru's slow `_get_lib_dirs()` — `remove()` re-acquires the same lock on the same thread → **self-deadlock**.

**Fix.** Guard loguru `add()`/`remove()` with a thread-local critical-section flag. While it's active, `_finalize_logger` **defers** the handler id to a queue instead of calling `remove()`; the queue is drained when the section exits and the lock is free (still flagged, so a finalizer firing mid-drain defers rather than deadlocks). `db_store.close()` is left as-is — its own per-env lock isn't a shared-lock hazard.

This was pinpointed by the `pytest-timeout` guard (separate commit on `main`), which converted the silent 20-min hang into a fast failure with a full thread-stack dump.

## Test plan
- [x] New deterministic regression test (`tests/core/test_logger_finalizer.py`) — finalizer defers (not removes) while flagged, and removes on drain. Fails before the fix, passes after. No PyPy needed.
- [x] Full suite green locally — 859 passed, 99.12% coverage
- [x] `ruff check src tests` + `ty check src` clean
- [ ] CI green across the matrix — **watch the PyPy 3.11 lane** (the frequent reproduction)